### PR TITLE
feat(renovate): automerge js dependencies too

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -24,8 +24,9 @@
   "packageRules": [
     {
       "automerge": true,
-      "description": "Automerge minor and patch updates for devDependencies if CI passes.",
+      "description": "Automerge minor and patch updates for dependencies and devDependencies if CI passes.",
       "matchDepTypes": [
+        "dependencies",
         "devDependencies"
       ],
       "matchUpdateTypes": [

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -9,6 +9,7 @@
   "labels": [
     "dependencies"
   ],
+  "rangeStrategy": "pin",
   "customManagers": [
     {
       "customType": "regex",

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -25,6 +25,17 @@
   "packageRules": [
     {
       "automerge": true,
+      "description": "Automerge minor and patch updates for custom regex managers (GitHub Releases).",
+      "matchDatasources": [
+        "github-releases"
+      ],
+      "matchUpdateTypes": [
+        "minor",
+        "patch"
+      ]
+    },
+    {
+      "automerge": true,
       "description": "Automerge minor and patch updates for dependencies and devDependencies if CI passes.",
       "matchDepTypes": [
         "dependencies",


### PR DESCRIPTION
Automerge never automerges major version changes.

* Automerge `dependencies` too, not just `depDependencies`
* Set range strategy to pin, just to be explicit
* Automerge customManagers too